### PR TITLE
Fix ReflectionMethod::__construct() deprecations

### DIFF
--- a/src/Subscribers/AttributeResolverTrait.php
+++ b/src/Subscribers/AttributeResolverTrait.php
@@ -25,7 +25,11 @@ trait AttributeResolverTrait
         $test = $this->parseMethod($test);
 
         try {
-            $method = ReflectionMethod::createFromMethodName($test);
+            if (PHP_VERSION_ID < 80300) {
+                $method = new ReflectionMethod($test);
+            } else {
+                $method = ReflectionMethod::createFromMethodName($test);
+            }
         } catch (Exception) {
             return null;
         }
@@ -48,7 +52,11 @@ trait AttributeResolverTrait
 
     private function getAttributeFromClass(string $test): ?UseCassette
     {
-        $method = ReflectionMethod::createFromMethodName($test);
+        if (PHP_VERSION_ID < 80300) {
+            $method = new ReflectionMethod($test);
+        } else {
+            $method = ReflectionMethod::createFromMethodName($test);
+        }
         $class = $method->getDeclaringClass();
         $attributes = $class->getAttributes(UseCassette::class);
 

--- a/src/Subscribers/AttributeResolverTrait.php
+++ b/src/Subscribers/AttributeResolverTrait.php
@@ -28,6 +28,7 @@ trait AttributeResolverTrait
             if (PHP_VERSION_ID < 80300) {
                 $method = new ReflectionMethod($test);
             } else {
+                // @phpstan-ignore-next-line
                 $method = ReflectionMethod::createFromMethodName($test);
             }
         } catch (Exception) {
@@ -55,6 +56,7 @@ trait AttributeResolverTrait
         if (PHP_VERSION_ID < 80300) {
             $method = new ReflectionMethod($test);
         } else {
+            // @phpstan-ignore-next-line
             $method = ReflectionMethod::createFromMethodName($test);
         }
         $class = $method->getDeclaringClass();

--- a/src/Subscribers/AttributeResolverTrait.php
+++ b/src/Subscribers/AttributeResolverTrait.php
@@ -25,7 +25,7 @@ trait AttributeResolverTrait
         $test = $this->parseMethod($test);
 
         try {
-            $method = new ReflectionMethod($test);
+            $method = ReflectionMethod::createFromMethodName($test);
         } catch (Exception) {
             return null;
         }
@@ -48,7 +48,7 @@ trait AttributeResolverTrait
 
     private function getAttributeFromClass(string $test): ?UseCassette
     {
-        $method = new ReflectionMethod($test);
+        $method = ReflectionMethod::createFromMethodName($test);
         $class = $method->getDeclaringClass();
         $attributes = $class->getAttributes(UseCassette::class);
 


### PR DESCRIPTION
Fixes the following issues:

1) /symfony/vendor/angelov/phpunit-php-vcr/src/Subscribers/AttributeResolverTrait.php:28 Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead

2) /symfony/vendor/angelov/phpunit-php-vcr/src/Subscribers/AttributeResolverTrait.php:51 Calling ReflectionMethod::__construct() with 1 argument is deprecated, use ReflectionMethod::createFromMethodName() instead

Deprecations reported when executing phpunit in php 8.4.