### PR TITLE
feat: Add support for separate cassettes per DataProvider cases

### DIFF
--- a/src/Subscribers/AttributeResolverTrait.php
+++ b/src/Subscribers/AttributeResolverTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Angelov\PHPUnitPHPVcr\Subscribers;
 
 use Angelov\PHPUnitPHPVcr\UseCassette;
+use Angelov\PHPUnitPHPVcr\Values\TestCaseParameters;
+use Angelov\PHPUnitPHPVcr\Values\TestMethodInfo;
 use Exception;
 use ReflectionMethod;
 
@@ -12,52 +14,56 @@ trait AttributeResolverTrait
 {
     private function needsRecording(string $test): bool
     {
-        return $this->getAttribute($test) !== null;
+        return $this->getTestCaseCassetteParameters($test) !== null;
     }
 
-    private function getCassetteName(string $test): ?string
+    private function getTestCaseCassetteParameters(string $test): ?TestCaseParameters
     {
-        return $this->getAttribute($test)?->name;
-    }
-
-    private function getAttribute(string $test): ?UseCassette
-    {
-        $test = $this->parseMethod($test);
+        $testMethodDetails = $this->parseMethod($test);
 
         try {
             if (PHP_VERSION_ID < 80300) {
-                $method = new ReflectionMethod($test);
+                $method = new ReflectionMethod($testMethodDetails->method);
             } else {
                 // @phpstan-ignore-next-line
-                $method = ReflectionMethod::createFromMethodName($test);
+                $method = ReflectionMethod::createFromMethodName($testMethodDetails->method);
             }
         } catch (Exception) {
             return null;
         }
 
-        $attributes = $method->getAttributes(UseCassette::class);
+        $cassetteAttribute = $method->getAttributes(UseCassette::class);
 
-        if ($attributes) {
-            return $attributes[0]->newInstance();
+        $cassetteAttributeInstance = $cassetteAttribute
+            ? $cassetteAttribute[0]->newInstance() : $this->getAttributeFromClass($testMethodDetails);
+
+        if ($cassetteAttributeInstance === null) {
+            return null;
         }
 
-        return $this->getAttributeFromClass($test);
+        return new TestCaseParameters(
+            cassetteInfo: $cassetteAttributeInstance,
+            case: $testMethodDetails->dataProvider,
+        );
     }
 
-    private function parseMethod(string $test): string
+    private function parseMethod(string $test): TestMethodInfo
     {
-        $test = explode(" ", $test)[0];
+        $methodDetails = explode("#", $test);
 
-        return explode("#", $test)[0];
+        return new TestMethodInfo(
+            method: $methodDetails[0],
+            dataProvider: $methodDetails[1] ?? null
+        );
     }
 
-    private function getAttributeFromClass(string $test): ?UseCassette
+    private function getAttributeFromClass(TestMethodInfo $test): ?UseCassette
     {
         if (PHP_VERSION_ID < 80300) {
-            $method = new ReflectionMethod($test);
+            $method = new ReflectionMethod($test->method);
         } else {
             // @phpstan-ignore-next-line
-            $method = ReflectionMethod::createFromMethodName($test);
+            $method = ReflectionMethod::createFromMethodName($test->method);
         }
         $class = $method->getDeclaringClass();
         $attributes = $class->getAttributes(UseCassette::class);

--- a/src/Subscribers/StartRecording.php
+++ b/src/Subscribers/StartRecording.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Angelov\PHPUnitPHPVcr\Subscribers;
 
+use Angelov\PHPUnitPHPVcr\UseCassette;
+use Angelov\PHPUnitPHPVcr\Values\TestCaseParameters;
 use PHPUnit\Event\Test\Prepared;
 use PHPUnit\Event\Test\PreparedSubscriber;
 use VCR\VCR;
@@ -20,10 +22,38 @@ class StartRecording implements PreparedSubscriber
             return;
         }
 
-        $cassetteName = $this->getCassetteName($test);
-        assert($cassetteName !== null);
+        $testCaseCassetteParameters = $this->getTestCaseCassetteParameters($test);
+        assert($testCaseCassetteParameters instanceof TestCaseParameters);
+
+        if ($testCaseCassetteParameters->case !== null) {
+            $cassetteName = $this->makeCassetteNameForCase(
+                case: $testCaseCassetteParameters->case,
+                cassetteInfo: $testCaseCassetteParameters->cassetteInfo,
+            );
+        } else {
+            $cassetteName = $testCaseCassetteParameters->cassetteInfo->name;
+        }
 
         VCR::turnOn();
         VCR::insertCassette($cassetteName);
+    }
+
+    private function makeCassetteNameForCase(string $case, UseCassette $cassetteInfo): string
+    {
+        if (!$cassetteInfo->separateCassettePerCase) {
+            return $cassetteInfo->name;
+        }
+
+        $cassetteNameParts = explode('.', $cassetteInfo->name);
+        $cassetteSuffix = $cassetteInfo->groupCaseFilesInDirectory ? '/' . $case : '-' . $case;
+
+        if (count($cassetteNameParts) === 1) {
+            //the cassette name does not contain a dot, so we can use it as is
+            return $cassetteInfo->name . $cassetteSuffix;
+        }
+
+        $ext = array_pop($cassetteNameParts);
+
+        return implode('.', $cassetteNameParts) . $cassetteSuffix . '.' . $ext;
     }
 }

--- a/src/UseCassette.php
+++ b/src/UseCassette.php
@@ -7,9 +7,12 @@ namespace Angelov\PHPUnitPHPVcr;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
-class UseCassette
+readonly class UseCassette
 {
-    public function __construct(public readonly string $name)
-    {
+    public function __construct(
+        public string $name,
+        public bool $separateCassettePerCase = false,
+        public bool $groupCaseFilesInDirectory = false
+    ) {
     }
 }

--- a/src/Values/TestCaseParameters.php
+++ b/src/Values/TestCaseParameters.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Angelov\PHPUnitPHPVcr\Values;
+
+use Angelov\PHPUnitPHPVcr\UseCassette;
+
+readonly class TestCaseParameters
+{
+    public function __construct(
+        public UseCassette $cassetteInfo,
+        public ?string $case = null,
+    ) {
+    }
+}

--- a/src/Values/TestMethodInfo.php
+++ b/src/Values/TestMethodInfo.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Angelov\PHPUnitPHPVcr\Values;
+
+use InvalidArgumentException;
+
+readonly class TestMethodInfo
+{
+    public ?string $dataProvider;
+
+    public function __construct(
+        public string $method,
+        ?string $dataProvider = null
+    ) {
+        $this->dataProvider = $this->normaliseDataProvider($dataProvider);
+    }
+
+    private function normaliseDataProvider(?string $dataProvider): ?string
+    {
+        if ($dataProvider === null) {
+            return null;
+        }
+
+        $replaced = (string)preg_replace('/-+/', '-', (string)preg_replace('/\W+/', '-', $dataProvider));
+
+        if ($replaced === '') {
+            throw new InvalidArgumentException('Invalid data provider name: ' . $dataProvider);
+        }
+
+        return trim(strtolower($replaced));
+    }
+}

--- a/tests/AttributeDeclaredOnClassWithSeparateCassettesInSeparateFoldersTest.php
+++ b/tests/AttributeDeclaredOnClassWithSeparateCassettesInSeparateFoldersTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Angelov\PHPUnitPHPVcr\Tests;
+
+use Angelov\PHPUnitPHPVcr\UseCassette;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[UseCassette(
+    name: "with_separate_cassettes_in_separated_folders/on_class.yml",
+    separateCassettePerCase: true,
+    groupCaseFilesInDirectory: true,
+)]
+class AttributeDeclaredOnClassWithSeparateCassettesInSeparateFoldersTest extends TestCase
+{
+    #[Test]
+    public function it_uses_vcr_on_methods_from_class_with_attribute(): void
+    {
+        $content = file_get_contents("https://example.com");
+
+        $this->assertSame("Example body for \"https://example.com\" without data provider", $content);
+    }
+
+    #[Test]
+    #[DataProvider("urls")]
+    public function it_uses_vcr_on_methods_with_data_provider(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\" with numeric urls", $url), $content);
+    }
+
+    #[Test]
+    #[DataProvider("namedUrls")]
+    public function it_uses_vcr_on_methods_with_data_provider_named_use_cases(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\" with named urls", $url), $content);
+    }
+
+    /** @return iterable<list<string>> */
+    public static function urls(): iterable
+    {
+        yield ["https://example.com"];
+        yield ["https://example.org"];
+    }
+
+    /** @return iterable<string, list<string>> */
+    public static function namedUrls(): iterable
+    {
+        yield 'example.com' => ["https://example.com"];
+        yield 'example.org' => ["https://example.org"];
+    }
+}

--- a/tests/AttributeDeclaredOnClassWithSeparateCassettesInSingleFolderTest.php
+++ b/tests/AttributeDeclaredOnClassWithSeparateCassettesInSingleFolderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Angelov\PHPUnitPHPVcr\Tests;
+
+use Angelov\PHPUnitPHPVcr\UseCassette;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[UseCassette(name: "with_separate_cassettes_in_single_folder/on_class.yml", separateCassettePerCase: true)]
+class AttributeDeclaredOnClassWithSeparateCassettesInSingleFolderTest extends TestCase
+{
+    #[Test]
+    public function it_uses_vcr_on_methods_from_class_with_attribute(): void
+    {
+        $content = file_get_contents("https://example.com");
+
+        $this->assertSame("Example body for \"https://example.com\"", $content);
+    }
+
+    #[Test]
+    #[DataProvider("urls")]
+    public function it_uses_vcr_on_methods_with_data_provider(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\"", $url), $content);
+    }
+
+    #[Test]
+    #[DataProvider("namedUrls")]
+    public function it_uses_vcr_on_methods_with_data_provider_named_use_cases(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\"", $url), $content);
+    }
+
+    /** @return iterable<list<string>> */
+    public static function urls(): iterable
+    {
+        yield ["https://example.com"];
+        yield ["https://example.org"];
+    }
+
+    /** @return iterable<string, list<string>> */
+    public static function namedUrls(): iterable
+    {
+        yield 'example.com' => ["https://example.com"];
+        yield 'example.org' => ["https://example.org"];
+    }
+}

--- a/tests/AttributeDeclaredOnMethodsTest.php
+++ b/tests/AttributeDeclaredOnMethodsTest.php
@@ -21,9 +21,56 @@ class AttributeDeclaredOnMethodsTest extends TestCase
     }
 
     #[Test]
+    #[UseCassette("on_methods_without_extension")]
+    public function it_uses_vcr_on_methods_with_attribute_cassette_without_extension(): void
+    {
+        $content = file_get_contents("https://example.com");
+
+        $this->assertSame("Example body.", $content);
+    }
+
+    #[Test]
+    #[UseCassette(
+        name: "on_methods_without_extension_with_data_provider",
+        separateCassettePerCase: true,
+        groupCaseFilesInDirectory:true,
+    )]
+    #[DataProvider("namedUrls")]
+    public function it_uses_vcr_on_methods_with_attribute_cassette_and_data_provider_without_extension(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\"", $url), $content);
+    }
+
+    #[Test]
     #[UseCassette("with_data_provider.yml")]
     #[DataProvider("urls")]
     public function it_uses_vcr_on_methods_with_data_provider(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\"", $url), $content);
+    }
+
+    #[Test]
+    #[UseCassette(name: "with_data_provider_and_separated_cassettes.yml", separateCassettePerCase: true)]
+    #[DataProvider("namedUrls")]
+    public function it_uses_vcr_on_methods_with_data_provider_and_separate_cassette_per_case(string $url): void
+    {
+        $content = file_get_contents($url);
+
+        $this->assertSame(sprintf("Example body for \"%s\"", $url), $content);
+    }
+
+    #[Test]
+    #[UseCassette(
+        name: "with_data_provider_and_separated_cassettes_in_directory.yml",
+        separateCassettePerCase: true,
+        groupCaseFilesInDirectory: true,
+    )]
+    #[DataProvider("urls")]
+    public function it_uses_vcr_on_methods_with_data_provider_and_separate_cassette_per_case_in_directories(string $url): void
     {
         $content = file_get_contents($url);
 
@@ -35,5 +82,13 @@ class AttributeDeclaredOnMethodsTest extends TestCase
     {
         yield ["https://example.com"];
         yield ["https://example.org"];
+    }
+
+    /** @return iterable<string, list<string>> */
+    public static function namedUrls(): iterable
+    {
+        yield 'example.com' => ["https://example.com"];
+        yield 'example.org' => ["https://example.org"];
+        yield 'test case with spaces' => ["https://example.org"];
     }
 }

--- a/tests/WithoutVcrTest.php
+++ b/tests/WithoutVcrTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Angelov\PHPUnitPHPVcr\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class WithoutVcrTest extends TestCase
+{
+    #[Test]
+    public function it_uses_vcr_on_methods_with_attribute(): void
+    {
+        // @phpstan-ignore-next-line method.alreadyNarrowedType
+        $this->assertTrue(true);
+    }
+}

--- a/tests/fixtures/on_methods_without_extension
+++ b/tests/fixtures/on_methods_without_extension
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '454479'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:07:20 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:07:20 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body."
+    index: 0

--- a/tests/fixtures/on_methods_without_extension_with_data_provider/example-com
+++ b/tests/fixtures/on_methods_without_extension_with_data_provider/example-com
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\""
+    index: 0

--- a/tests/fixtures/on_methods_without_extension_with_data_provider/example-org
+++ b/tests/fixtures/on_methods_without_extension_with_data_provider/example-org
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\""
+    index: 0

--- a/tests/fixtures/on_methods_without_extension_with_data_provider/test-case-with-spaces
+++ b/tests/fixtures/on_methods_without_extension_with_data_provider/test-case-with-spaces
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\""
+    index: 0

--- a/tests/fixtures/with_data_provider_and_separated_cassettes-example-com.yml
+++ b/tests/fixtures/with_data_provider_and_separated_cassettes-example-com.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\""
+    index: 0

--- a/tests/fixtures/with_data_provider_and_separated_cassettes-example-org.yml
+++ b/tests/fixtures/with_data_provider_and_separated_cassettes-example-org.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\""
+    index: 0

--- a/tests/fixtures/with_data_provider_and_separated_cassettes-test-case-with-spaces.yml
+++ b/tests/fixtures/with_data_provider_and_separated_cassettes-test-case-with-spaces.yml
@@ -1,0 +1,24 @@
+-
+  request:
+    method: GET
+    url: 'https://example.org'
+    headers:
+      Host: example.org
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      age: '331432'
+      cache-control: max-age=604800
+      content-type: 'text/html; charset=UTF-8'
+      date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+      etag: '"3147526947+ident"'
+      expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+      last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+      server: 'ECS (dcb/7F83)'
+      vary: Accept-Encoding
+      x-cache: HIT
+      content-length: '1256'
+    body: "Example body for \"https://example.org\""
+  index: 0

--- a/tests/fixtures/with_data_provider_and_separated_cassettes_in_directory/0.yml
+++ b/tests/fixtures/with_data_provider_and_separated_cassettes_in_directory/0.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\""
+    index: 0

--- a/tests/fixtures/with_data_provider_and_separated_cassettes_in_directory/1.yml
+++ b/tests/fixtures/with_data_provider_and_separated_cassettes_in_directory/1.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\""
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class.yml
+++ b/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class.yml
@@ -1,0 +1,24 @@
+-
+  request:
+    method: GET
+    url: 'https://example.com'
+    headers:
+      Host: example.com
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      age: '455285'
+      cache-control: max-age=604800
+      content-type: 'text/html; charset=UTF-8'
+      date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+      etag: '"3147526947+ident"'
+      expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+      last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+      server: 'ECS (dcb/7EA3)'
+      vary: Accept-Encoding
+      x-cache: HIT
+      content-length: '1256'
+    body: "Example body for \"https://example.com\" without data provider"
+  index: 0

--- a/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/0.yml
+++ b/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/0.yml
@@ -1,0 +1,24 @@
+-
+  request:
+    method: GET
+    url: 'https://example.com'
+    headers:
+      Host: example.com
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      age: '455285'
+      cache-control: max-age=604800
+      content-type: 'text/html; charset=UTF-8'
+      date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+      etag: '"3147526947+ident"'
+      expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+      last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+      server: 'ECS (dcb/7EA3)'
+      vary: Accept-Encoding
+      x-cache: HIT
+      content-length: '1256'
+    body: "Example body for \"https://example.com\" with numeric urls"
+  index: 0

--- a/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/1.yml
+++ b/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/1.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\" with numeric urls"
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/example-com.yml
+++ b/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/example-com.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\" with named urls"
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/example-org.yml
+++ b/tests/fixtures/with_separate_cassettes_in_separated_folders/on_class/example-org.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\" with named urls"
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-0.yml
+++ b/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-0.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\""
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-1.yml
+++ b/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-1.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\""
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-example-com.yml
+++ b/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-example-com.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\""
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-example-org.yml
+++ b/tests/fixtures/with_separate_cassettes_in_single_folder/on_class-example-org.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.org'
+        headers:
+            Host: example.org
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '331432'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:17:02 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:17:02 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7F83)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.org\""
+    index: 0

--- a/tests/fixtures/with_separate_cassettes_in_single_folder/on_class.yml
+++ b/tests/fixtures/with_separate_cassettes_in_single_folder/on_class.yml
@@ -1,0 +1,24 @@
+-
+    request:
+        method: GET
+        url: 'https://example.com'
+        headers:
+            Host: example.com
+    response:
+        status:
+            code: 200
+            message: ''
+        headers:
+            age: '455285'
+            cache-control: max-age=604800
+            content-type: 'text/html; charset=UTF-8'
+            date: 'Sun, 12 Mar 2023 10:20:46 GMT'
+            etag: '"3147526947+ident"'
+            expires: 'Sun, 19 Mar 2023 10:20:46 GMT'
+            last-modified: 'Thu, 17 Oct 2019 07:18:26 GMT'
+            server: 'ECS (dcb/7EA3)'
+            vary: Accept-Encoding
+            x-cache: HIT
+            content-length: '1256'
+        body: "Example body for \"https://example.com\""
+    index: 0


### PR DESCRIPTION
This PR introduces comprehensive support for creating separate VCR cassettes for each PHPUnit DataProvider case, providing better isolation and organization of HTTP recordings in data-driven tests.

### 🚀 New Features

#### Enhanced UseCassette Attribute
- **`separateCassettePerCase`**: When set to `true`, creates individual cassette files for each data provider case
- **`groupCaseFilesInDirectory`**: When set to `true`, organizes separate cassette files in subdirectories

#### Flexible Cassette Naming Strategies
- **Numbered cases**: `cassette-0.yml`, `cassette-1.yml`
- **Named cases**: `cassette-example-com.yml`, `cassette-example-org.yml`
- **Directory organization**: `cassette/0.yml`, `cassette/example-com.yml`
- **Extension handling**: Works with and without file extensions

#### Class and Method Level Support
- Works with `UseCassette` declared on test classes
- Works with `UseCassette` declared on individual test methods
- Maintains backward compatibility with existing usage

### 🔧 Implementation Details

#### Core Changes
- **UseCassette.php**: Enhanced with new optional parameters
- **AttributeResolverTrait.php**: Refactored to parse data provider information
- **StartRecording.php**: Added intelligent cassette naming logic
- **New Value Objects**: `TestCaseParameters` and `TestMethodInfo` for better data handling

#### Data Provider Name Normalization
- Converts special characters to hyphens
- Handles edge cases and invalid names
- Maintains consistency across different naming patterns

### 📚 Documentation
- Comprehensive README updates with multiple usage examples
- Examples for all supported configurations
- Clear migration path for existing users

### 🧪 Test Coverage
- **New Test Classes**: 
  - `AttributeDeclaredOnClassWithSeparateCassettesInSeparateFoldersTest`
  - `AttributeDeclaredOnClassWithSeparateCassettesInSingleFolderTest`
  - `WithoutVcrTest`
- **Enhanced Existing Tests**: Updated `AttributeDeclaredOnMethodsTest` with new scenarios
- **Complete Fixture Set**: 20+ test fixtures demonstrating all naming patterns and organization strategies

### 🔄 Backward Compatibility
- All existing functionality remains unchanged
- New parameters are optional with sensible defaults
- No breaking changes to existing API

### 💡 Usage Examples

#### Basic Separate Cassettes
```php
#[UseCassette(name: "api_test.yml", separateCassettePerCase: true)]
#[DataProvider("urls")]
public function testApiCalls(string $url): void
{
    // Creates: api_test-0.yml, api_test-1.yml
}
```

#### Organized in Directories
```php
#[UseCassette(
    name: "api_test.yml", 
    separateCassettePerCase: true,
    groupCaseFilesInDirectory: true
)]
#[DataProvider("namedUrls")]
public function testApiCalls(string $url): void
{
    // Creates: api_test/example-com.yml, api_test/example-org.yml
}
```

This enhancement significantly improves the developer experience when working with data-driven tests that make HTTP requests, providing better isolation, easier debugging, and more organized test fixtures.